### PR TITLE
Add a (failing) test for cond.

### DIFF
--- a/spec.hs
+++ b/spec.hs
@@ -29,6 +29,9 @@ main = hspec $ do
           "(abs (- 1))"] "Number 1"
     test ["(define (abs x) (cond ((< x 0) (- x)) (else x)))",
           "(abs (- 10))"] "Number 10"
+    test ["(cond (1 1) (else 2))"] "Number 1" -- currently produces "Number 2"
+    -- analogous test for `if`
+    test ["(if 1 1 2)"] "Number 1"
 
     -- parsing has some problems with spaces
     test ["( * 2 2 )"] "Number 4" -- currently a parse error


### PR DESCRIPTION
`cond` should behave like `if` in treating everything except `#f` as true.